### PR TITLE
chore: add .gitattributes to let github know this mainly a markdown repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.md linguist-detectable
+/**/README.md -linguist-detectable


### PR DESCRIPTION
Languages are currently hidden from the repo info because only Markdown is found, and that is hidden by default.

This change causes GitHub to recognize that the repo sources are currently mainly Markdown, and will show this in the languages section of the repo.

We also normalize line endings with `* text=auto eol=lf`.

See linguistic docs at https://github.com/github/linguist/blob/master/docs/overrides.md#detectable